### PR TITLE
Include EU-DEM rename script in git repo

### DIFF
--- a/docs/datasets/eudem.md
+++ b/docs/datasets/eudem.md
@@ -57,30 +57,7 @@ Next, Open Topo Data needs the filenames to match the SRTM format: the filename 
 
 So `eu_dem_v11_E00N20.TIF` becomes `N2000000E0000000.tif`. Here's a Python script to do the transformation, but it might be just as easy to do by hand:
 
-```python
-from glob import glob
-import os
-import re
-
-old_pattern = './data/eudem/eu_dem_v11_E*N*.TIF'
-old_paths = list(glob(old_pattern))
-print('Found {} files'.format(len(old_paths)))
-
-for old_path in old_paths:
-    folder = os.path.dirname(old_path)
-    old_filename = os.path.basename(old_path)
-
-    # Extract north and east coords, pad with zeroes.
-    res = re.search(r'(E\d\d)(N\d\d)', old_filename)
-    easting, northing = res.groups()
-    northing = northing + '00000'
-    easting = easting + '00000'
-
-    # Rename in place.
-    new_filename = '{}{}.tif'.format(northing, easting)
-    new_path = os.path.join(folder, new_filename)
-    os.rename(old_path, new_path)
-```
+[rename_eudem.py](https://github.com/ajnisbet/opentopodata/blob/dev/rename_eudem.py)
 
 You should have the following 27 files:
 

--- a/rename_eudem.py
+++ b/rename_eudem.py
@@ -1,0 +1,22 @@
+from glob import glob
+import os
+import re
+
+old_pattern = './data/eudem/eu_dem_v11_E*N*.TIF'
+old_paths = list(glob(old_pattern))
+print('Found {} files'.format(len(old_paths)))
+
+for old_path in old_paths:
+    folder = os.path.dirname(old_path)
+    old_filename = os.path.basename(old_path)
+
+    # Extract north and east coords, pad with zeroes.
+    res = re.search(r'(E\d\d)(N\d\d)', old_filename)
+    easting, northing = res.groups()
+    northing = northing + '00000'
+    easting = easting + '00000'
+
+    # Rename in place.
+    new_filename = '{}{}.tif'.format(northing, easting)
+    new_path = os.path.join(folder, new_filename)
+    os.rename(old_path, new_path)


### PR DESCRIPTION
The renaming script from https://www.opentopodata.org/datasets/eudem/ is very useful for setting up the EU-DEM data for usage with OpenTopoData. It would be even more useful if it was included in the git repo, so that one could directly run it on the server.

The first commit in this PR adds the script to the repo (I'm simply putting it in the base dir, but one could also move it into a new subdir, e.g. `util/` or `scripts/`).

The second commit removes the script from the EU-DEM page and replaces it by a link, in order to avoid duplication. That's kind of optional.